### PR TITLE
refetched user balances after creating new order and cancelling an order

### DIFF
--- a/src/components/trade/account/Orders.svelte
+++ b/src/components/trade/account/Orders.svelte
@@ -20,11 +20,12 @@
 	} from '@lib/formatters'
 	import { XMARK_ICON, CHAINLINK_LOGO, LOADING_ICON } from '@lib/icons'
 
-	import { address, ordersSortKey, ordersSorted, ordersColumnsToShow, marketInfos } from '@lib/stores'
+	import { address, ordersSortKey, ordersSorted, ordersColumnsToShow, marketInfos, selectedAsset } from '@lib/stores'
 	import { showModal } from '@lib/ui'
 	import { saveUserSetting } from '@lib/utils'
 
 	import { cancelOrder, selfExecuteOrder, getUserOrders } from '@api/orders'
+	import { getUserAssetBalances } from '@api/assets'
 
 	export let allColumns;
 
@@ -46,6 +47,7 @@
 		ordersCancelling[orderId] = true;
 		const success = await cancelOrder(orderId);
 		ordersCancelling[orderId] = false;
+		await getUserAssetBalances([$selectedAsset]);
 	}
 
 	let ordersSelfExecuting = {};

--- a/src/components/trade/order/NewOrder.svelte
+++ b/src/components/trade/order/NewOrder.svelte
@@ -66,8 +66,9 @@
 			if ($orderType == 2) return focusInput('Stop Price');
 		}
 		if ($hasTPSL && !$tpPrice && !$slPrice) return focusInput('TP Price');
-		submitOrder();
 		highlightedPriceButton = null;
+		await submitOrder();
+		fetchData()
 	}
 
 	let isApproving = false;


### PR DESCRIPTION
I was able to recreate the issue by changing my wallet balance. The client still shows the buying power which corresponds to the same balance as before changing the wallet balance. 

I have fixed this by calling the getUserAssetBalances() method when the user: 
1. Creates a new order
2. Cancels an order

This issue can also be caused if the user transfers their assets to another wallet (which has nothing to do with CAP), but still needs to be fixed.

A much more solid fix is to use the ethereum API to listen to transactions to the user's wallet, and then calling getUserAssetBalances(). I'll work on that later.