### PR TITLE
Add shortcuts for staking/unstaking max amount

### DIFF
--- a/src/api/cap.js
+++ b/src/api/cap.js
@@ -19,9 +19,9 @@ export async function getUserCAPStake() {
 }
 
 export async function getCapWalletBalance() {
-	const _address = get(address);
+	if (!get(address)) return 0;
 	const contract = await getContract("CAP", true);
-	const balance = await contract.balanceOf(_address);
+	const balance = await contract.balanceOf(get(address));
 	return formatUnits(balance);
 }
 

--- a/src/api/cap.js
+++ b/src/api/cap.js
@@ -18,7 +18,7 @@ export async function getUserCAPStake() {
 	CAPStake.set(formatUnits(balance));
 }
 
-export async function getCapWalletBalance() {
+export async function getCAPWalletBalance() {
 	if (!get(address)) return 0;
 	const contract = await getContract("CAP", true);
 	const balance = await contract.balanceOf(get(address));

--- a/src/api/cap.js
+++ b/src/api/cap.js
@@ -18,6 +18,13 @@ export async function getUserCAPStake() {
 	CAPStake.set(formatUnits(balance));
 }
 
+export async function getCapWalletBalance() {
+	const _address = get(address);
+	const contract = await getContract("CAP", true);
+	const balance = await contract.balanceOf(_address);
+	return formatUnits(balance);
+}
+
 export async function getClaimableRewardsCAP() {
 	if (!get(address)) return;
 	const contract = await getContract('Staking');

--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -62,8 +62,9 @@
 			<div class="group">
 				<Input label='Amount' bind:value={amount} />
 				<LabelValue
-					label="Wallet Balance:"
+					label="Wallet Balance"
 					value={walletBalance}
+					formatValue={true}
 					isClickable={true}
 					hasSemiPadding={true}
 					on:click={() => { amount = walletBalance; }}

--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -8,7 +8,6 @@
 
 	import { depositCAP, getCapWalletBalance } from '@api/cap'
 	import { approveAsset, getAllowance } from '@api/assets'
-	import { formatForDisplay } from '@lib/formatters'
 	import { allowances } from '@lib/stores'
 	import { focusInput, hideModal } from '@lib/ui'
 	import LabelValue from '../layout/LabelValue.svelte'
@@ -64,10 +63,10 @@
 				<Input label='Amount' bind:value={amount} />
 				<LabelValue
 					label="Wallet Balance:"
-					value={formatForDisplay(walletBalance, 6)}
+					value={walletBalance}
 					isClickable={true}
 					hasSemiPadding={true}
-					on:click={() => { amount = formatForDisplay(walletBalance, 6); }}
+					on:click={() => { amount = walletBalance; }}
 				/>
 			</div>
 

--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -8,11 +8,14 @@
 
 	import { depositCAP, getCapWalletBalance } from '@api/cap'
 	import { approveAsset, getAllowance } from '@api/assets'
+	import { formatCAPForDisplay } from "@lib/formatters"
 	import { allowances } from '@lib/stores'
 	import { focusInput, hideModal } from '@lib/ui'
 	import LabelValue from '../layout/LabelValue.svelte'
 
-	let amount, isSubmitting, walletBalance = 0;
+	let amount, isSubmitting, walletBalance = "0.0";
+
+	$: formattedWalletBalance = formatCAPForDisplay(walletBalance);
 
 	async function submit() {
 
@@ -63,11 +66,10 @@
 				<Input label='Amount' bind:value={amount} />
 				<LabelValue
 					label="Wallet Balance"
-					value={walletBalance}
-					formatValue={true}
+					value={formattedWalletBalance}
 					isClickable={true}
 					hasSemiPadding={true}
-					on:click={() => { amount = walletBalance; }}
+					on:click={() => { amount = formattedWalletBalance; }}
 				/>
 			</div>
 

--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -6,7 +6,7 @@
 	
 	import { onMount } from 'svelte'
 
-	import { depositCAP, getCapWalletBalance } from '@api/cap'
+	import { depositCAP, getCAPWalletBalance } from '@api/cap'
 	import { approveAsset, getAllowance } from '@api/assets'
 	import { formatCAPForDisplay } from "@lib/formatters"
 	import { allowances } from '@lib/stores'
@@ -39,7 +39,7 @@
 	}
 
 	async function getBalance() {
-		walletBalance = await getCapWalletBalance();
+		walletBalance = await getCAPWalletBalance();
 	}
 
 	checkAllowance();

--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -6,12 +6,14 @@
 	
 	import { onMount } from 'svelte'
 
-	import { depositCAP } from '@api/cap'
+	import { depositCAP, getCapWalletBalance } from '@api/cap'
 	import { approveAsset, getAllowance } from '@api/assets'
+	import { formatForDisplay } from '@lib/formatters'
 	import { allowances } from '@lib/stores'
 	import { focusInput, hideModal } from '@lib/ui'
+	import LabelValue from '../layout/LabelValue.svelte'
 
-	let amount, isSubmitting;
+	let amount, isSubmitting, walletBalance = 0;
 
 	async function submit() {
 
@@ -34,7 +36,12 @@
 		const result = await approveAsset('CAP', 'FundStore');
 	}
 
+	async function getBalance() {
+		walletBalance = await getCapWalletBalance();
+	}
+
 	checkAllowance();
+	getBalance();
 
 	onMount(() => {
 		focusInput('Amount');
@@ -55,6 +62,13 @@
 
 			<div class="group">
 				<Input label='Amount' bind:value={amount} />
+				<LabelValue
+					label="Wallet Balance:"
+					value={formatForDisplay(walletBalance, 6)}
+					isClickable={true}
+					hasSemiPadding={true}
+					on:click={() => { amount = formatForDisplay(walletBalance, 6); }}
+				/>
 			</div>
 
 			<div>

--- a/src/components/modals/UnstakeCAP.svelte
+++ b/src/components/modals/UnstakeCAP.svelte
@@ -46,8 +46,9 @@
 			<div class="group">
 				<Input label='Amount' bind:value={amount} />
 				<LabelValue
-					label="CAP Staked:"
+					label="CAP Staked"
 					value={$CAPStake}
+					formatValue={true}
 					isClickable={true}
 					hasSemiPadding={true}
 					on:click={() => { amount = $CAPStake; }}

--- a/src/components/modals/UnstakeCAP.svelte
+++ b/src/components/modals/UnstakeCAP.svelte
@@ -3,10 +3,12 @@
 	import Modal from './Modal.svelte'
 	import Input from '@components/layout/Input.svelte'
 	import Button from '@components/layout/Button.svelte'
+	import LabelValue from '@components/layout/LabelValue.svelte'
 
 	import { onMount } from 'svelte'
 
 	import { withdrawCAP } from '@api/cap'
+	import { CAPStake } from '@lib/stores'
 	import { focusInput, hideModal } from '@lib/ui'
 
 	let amount, isSubmitting;
@@ -43,6 +45,13 @@
 		<form on:submit|preventDefault={submit}>
 			<div class="group">
 				<Input label='Amount' bind:value={amount} />
+				<LabelValue
+					label="CAP Staked:"
+					value={$CAPStake}
+					isClickable={true}
+					hasSemiPadding={true}
+					on:click={() => { amount = $CAPStake; }}
+				/>
 			</div>
 
 			<div>

--- a/src/components/modals/UnstakeCAP.svelte
+++ b/src/components/modals/UnstakeCAP.svelte
@@ -8,10 +8,13 @@
 	import { onMount } from 'svelte'
 
 	import { withdrawCAP } from '@api/cap'
+	import { formatCAPForDisplay } from '@lib/formatters'
 	import { CAPStake } from '@lib/stores'
 	import { focusInput, hideModal } from '@lib/ui'
 
 	let amount, isSubmitting;
+
+	$: formattedCAPStaked = formatCAPForDisplay($CAPStake);
 
 	async function submit() {
 
@@ -47,11 +50,10 @@
 				<Input label='Amount' bind:value={amount} />
 				<LabelValue
 					label="CAP Staked"
-					value={$CAPStake}
-					formatValue={true}
+					value={formattedCAPStaked}
 					isClickable={true}
 					hasSemiPadding={true}
-					on:click={() => { amount = $CAPStake; }}
+					on:click={() => { amount = formattedCAPStaked; }}
 				/>
 			</div>
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -34,6 +34,8 @@ export const CURRENCY_DECIMALS = {
 	CAP: 18
 }
 
+export const MAX_CAP_DISPLAY_DECIMALS = 6;
+
 export const USD_CONVERSION_MARKETS = {
 	ETH: 'ETH-USD',
 	WBTC: 'BTC-USD'

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store'
 import { ethers } from 'ethers'
-import { ADDRESS_ZERO, BPS_DIVIDER } from './config'
+import { ADDRESS_ZERO, BPS_DIVIDER, MAX_CAP_DISPLAY_DECIMALS } from './config'
 import { locale } from './stores'
 import { getLabelForAsset } from './utils'
 
@@ -114,7 +114,19 @@ export function formatForDisplay(amount, fix) {
 
 export function numberWithCommas(amount) {   // Get Commafied Value 
 	let formattedAmount = formatForDisplay(amount) * 1;
-    return formattedAmount.toLocaleString(get(locale));
+	return formattedAmount.toLocaleString(get(locale));
+}
+
+export function formatCAPForDisplay(amountStr) {
+	const significand = amountStr.split(".")[1] ?? "0";
+	const digits = MAX_CAP_DISPLAY_DECIMALS;
+	const needsBump = Array.from(significand.slice(digits)).some(d => d !== "0");
+	let balance = ethers.FixedNumber.fromString(amountStr);
+	if (needsBump) {
+		const bump = ethers.FixedNumber.fromString(parseFloat(`5e-${digits + 1}`).toFixed(18));
+		balance = balance.addUnsafe(bump).round(digits);
+	}
+	return balance.toString();
 }
 
 export function formatOrderType(orderType) {

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -118,14 +118,12 @@ export function numberWithCommas(amount) {   // Get Commafied Value
 }
 
 export function formatCAPForDisplay(amountStr) {
+	const amount = amountStr * 1;
 	const digits = MAX_CAP_DISPLAY_DECIMALS;
-	const dust = parseInt((amountStr.split(".")[1] ?? "0").slice(digits), 10) || 0;
-	let balance = ethers.FixedNumber.fromString(amountStr);
-	if (dust > 0) {
-		const bump = ethers.FixedNumber.fromString(parseFloat(`5e-${digits+1}`).toFixed(18));
-		balance = balance.addUnsafe(bump).round(digits);
-	}
-	return balance.toString();
+	const minIncrement = 10**-digits;
+	if (!amount) return 0;
+	if (amount <= minIncrement) return minIncrement;
+	return Math.ceil(amount * 10**digits) / 10**digits;
 }
 
 export function formatOrderType(orderType) {

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -118,12 +118,11 @@ export function numberWithCommas(amount) {   // Get Commafied Value
 }
 
 export function formatCAPForDisplay(amountStr) {
-	const significand = amountStr.split(".")[1] ?? "0";
 	const digits = MAX_CAP_DISPLAY_DECIMALS;
-	const needsBump = Array.from(significand.slice(digits)).some(d => d !== "0");
+	const dust = parseInt((amountStr.split(".")[1] ?? "0").slice(digits), 10) || 0;
 	let balance = ethers.FixedNumber.fromString(amountStr);
-	if (needsBump) {
-		const bump = ethers.FixedNumber.fromString(parseFloat(`5e-${digits + 1}`).toFixed(18));
+	if (dust > 0) {
+		const bump = ethers.FixedNumber.fromString(parseFloat(`5e-${digits+1}`).toFixed(18));
 		balance = balance.addUnsafe(bump).round(digits);
 	}
 	return balance.toString();


### PR DESCRIPTION
This PR addresses issue #22 by showing a user's CAP balance when staking and the amount of CAP they have staked when unstaking. Both of these values, when clicked, will update the relevant `Input` component accordingly.

The StakeCap modal is updated to display the user's wallet balance in CAP:
![cap_staking](https://user-images.githubusercontent.com/120074542/206548318-64a0e0a6-cfb7-4ada-a85d-c359d87c78b7.png)

The UnstakeCap modal is updated to display the amount of CAP the user currently has staked:
![cap_unstaking](https://user-images.githubusercontent.com/120074542/206548332-4e988e47-fa11-469a-b6ce-9a2b926e9d5a.png)

In both cases we use the unformatted value for the amount of CAP a user has so they really can stake/unstake **all** of their CAP. This level of precision doesn't play well with the `Input` or `LabelValue` styling, but as a first pass it made sense to me to choose precision over aesthetics. In testing, I was originally doing `formatForDisplay(val, 6)` as that seemed like enough precision to me, but in that case the fixed digits after the decimal made things ugly when the user wanted to stake/unstake a round number of CAP. Happy to update to match whatever your preference on this is @kappacappa.