### PR TITLE
Reset new order fields on market change

### DIFF
--- a/src/components/trade/order/NewOrder.svelte
+++ b/src/components/trade/order/NewOrder.svelte
@@ -129,18 +129,19 @@
 	$: checkWarning($prices[$selectedMarket], $price, $orderType, $isLong);
 	
   	// reset inputs on market change
-	  function resetOrderFields() {
-    	setPrice();
-    	price.set();
-    	size.set();
-    	tpPrice.set();
-    	slPrice.set();
-    	hasTPSL.set(false);
+	function resetOrderFields() {
+    		setPrice();
+    		price.set();
+    		size.set();
+    		tpPrice.set();
+    		slPrice.set();
+    		hasTPSL.set(false);
 		isReduceOnly.set(false)
-    	isProtectedOrder.set(false);
+    		isProtectedOrder.set(false);
 	}
 	
   	selectedMarket.subscribe(resetOrderFields);
+	
 </script>
 
 <style>

--- a/src/components/trade/order/NewOrder.svelte
+++ b/src/components/trade/order/NewOrder.svelte
@@ -127,7 +127,20 @@
 	}
 
 	$: checkWarning($prices[$selectedMarket], $price, $orderType, $isLong);
-
+	
+  	// reset inputs on market change
+	  function resetOrderFields() {
+    	setPrice();
+    	price.set();
+    	size.set();
+    	tpPrice.set();
+    	slPrice.set();
+    	hasTPSL.set(false);
+		isReduceOnly.set(false)
+    	isProtectedOrder.set(false);
+	}
+	
+  	selectedMarket.subscribe(resetOrderFields);
 </script>
 
 <style>


### PR DESCRIPTION
solutions for #33 

resets following on market change:
- price
- size
- tpPrice
- slPrice
- hasTPSL
- reduceOnly
- isProtectedOrder