### PR TITLE
Fix - 0x leverage

### DIFF
--- a/src/components/layout/Slider.svelte
+++ b/src/components/layout/Slider.svelte
@@ -68,6 +68,9 @@
 		}
 		value = formatForDisplay(progressPercent * maxValue / 100);
 		if (integersOnly) {
+			if(value < 1){
+				value = 1; // min leverage
+			}
 			value = Math.round(value);
 		}
 	}


### PR DESCRIPTION
Concerns issue #49. 

As rounding shenanigans are the reason 0x leverage is possible, we just check if value < 1 and if so set it to be 1.