### PR TITLE
Issue #4 and #11 - Edit Margin modal now shows updated liq price/margin/leverage data || Number formatting fixed

### DIFF
--- a/src/components/layout/DropdownInput.svelte
+++ b/src/components/layout/DropdownInput.svelte
@@ -27,6 +27,19 @@
 
 	}
 
+	function valueChecker(number) {
+
+		value = Number(parseFloat(number).toFixed(7))
+		
+		if (value > 10000000)
+		{
+			value = 10000000
+		}
+	}
+
+	$: valueChecker(value)
+
+
 </script>
 
 <style>

--- a/src/components/layout/Input.svelte
+++ b/src/components/layout/Input.svelte
@@ -18,6 +18,19 @@
 	export let isHighlighted = false;
 	export let isInvalid = false;
 
+	function valueChecker(number) {
+
+		value = Number(parseFloat(number).toFixed(7))
+		
+		if (value > 10000000)
+		{
+			value = 10000000
+		}
+
+	}
+
+	$: valueChecker(value)
+
 </script>
 
 <style>


### PR DESCRIPTION
Added a small information box to the Edit Margin modal that displays the new Liquidation Price, Margin and Leverage to the user.

Addresses Issue #4 

----

Accidentally pushed the fix to Issue #11 to this PR , so it goes here I guess

Issue #11 Fixed - Numbers now limited to a maximum of 10000000 and 7 decimal digits