### PR TITLE
Issue #24 - Added referral fee discount to Fee Discounts modal + quick fix for Margin input allowing more than 4 decimal digits

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,8 +20,8 @@
 
 	let interval1;
 
-	let checkingCode = true;
-	let codeValid = false;
+	let checkingCode = false;
+	let codeValid = true;
 	let error = false;
 	let code = localStorage.getItem('betaCode');
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,8 +20,8 @@
 
 	let interval1;
 
-	let checkingCode = false;
-	let codeValid = true;
+	let checkingCode = true;
+	let codeValid = false;
 	let error = false;
 	let code = localStorage.getItem('betaCode');
 

--- a/src/api/discounts.js
+++ b/src/api/discounts.js
@@ -2,7 +2,7 @@ import { get } from 'svelte/store'
 import { BPS_DIVIDER } from '@lib/config'
 import { getContract } from '@lib/contracts'
 import { formatUnits, parseUnits, formatFeeStat } from '@lib/formatters'
-import { address, trailing30dayVolume, currentFeeRebate, feeRebateFromVolume, feeRebateFromStaking, rebateParams, totalFeesSaved } from '@lib/stores'
+import { address, trailing30dayVolume, currentFeeRebate, feeRebateFromVolume, feeRebateFromStaking, rebateParams, totalFeesSaved, feeRebateFromReferral } from '@lib/stores'
 import { getChainData, getLabelForAsset } from '@lib/utils'
 import { showToast, showError } from '@lib/ui'
 
@@ -27,6 +27,14 @@ export async function getUserStakingRebate() {
 	if (!get(address)) return 0;
 	const contract = await getContract('RebateStore');
 	feeRebateFromStaking.set(await contract.getStakingRebate(get(address)) / BPS_DIVIDER);
+}
+
+export async function getReferralRebate() {
+	const contract = await getContract('ReferralStore');
+	const _address = get(address);
+	if (!_address) return 0;
+	const rebate = await contract.getRebateForUser(_address);
+	feeRebateFromReferral.set((rebate / BPS_DIVIDER));
 }
 
 export async function getRebateParams() {

--- a/src/components/modals/FeeDiscounts.svelte
+++ b/src/components/modals/FeeDiscounts.svelte
@@ -7,9 +7,9 @@
 	import LabelValue from '@components/layout/LabelValue.svelte'
 
 	import { formatForDisplay, letterify } from '@lib/formatters'
-	import { getUserVolume, getUserRebate, getUserVolumeRebate, getUserStakingRebate, getRebateParams, getUserFeesSaved } from '@api/discounts'
+	import { getUserVolume, getUserRebate, getUserVolumeRebate, getUserStakingRebate, getRebateParams, getUserFeesSaved, getReferralRebate } from '@api/discounts'
 	import { getUserCAPStake } from '@api/cap'
-	import { address, CAPStake, trailing30dayVolume, currentFeeRebate, feeRebateFromVolume, feeRebateFromStaking, totalFeesSaved, rebateParams } from '@lib/stores'
+	import { address, CAPStake, trailing30dayVolume, currentFeeRebate, feeRebateFromVolume, feeRebateFromStaking, totalFeesSaved, rebateParams, feeRebateFromReferral } from '@lib/stores'
 	import { getAssets } from '@lib/utils'
 
 	let assets = getAssets();
@@ -25,6 +25,7 @@
 		getUserFeesSaved();
 		getRebateParams();
 		getUserCAPStake();
+		getReferralRebate();
 		t = setTimeout(fetchData, 60 * 1000);
 	}
 	$: fetchData($address);
@@ -68,6 +69,10 @@
 	<div class='row nb'><LabelValue hasPadding={true} label='CAP Staked' value={`${formatForDisplay($CAPStake)}`} /></div>
 	<div class='row nb hasNote'><LabelValue hasPadding={true} label='Discount from CAP Staking' value={`${100 * $feeRebateFromStaking}%`} /></div>
 	<div class='note b'>Discount starts at <strong>{formatForDisplay($rebateParams[6]/100)}%</strong> for <strong>{$rebateParams[4]}</strong> CAP staked and increases up to <strong>{formatForDisplay($rebateParams[7]/100)}%</strong> for <strong>{$rebateParams[5]}</strong> CAP staked.</div>
+
+	<div class='row nb hasNote'><LabelValue hasPadding={true} label='Discount from Referral Code' value={`${100 * $feeRebateFromReferral}%`} /></div>
+	<div class='note b'>Use a referral code to get a <strong>10%</strong> discount on your fees.</div>
+
 
 	{#each assets as asset}
 		<div class='row nb'><LabelValue hasPadding={true} label={`Total Fees Saved (${asset})`} value={formatForDisplay($totalFeesSaved[asset]) || 0} /></div>

--- a/src/components/trade/order/NewOrder.svelte
+++ b/src/components/trade/order/NewOrder.svelte
@@ -301,7 +301,7 @@
 			{/if}
 
 			<div class='top-spacing bottom-spacing'>
-				<DDInput label='Size' setDisplaySizeOrMargin={setDisplaySizeOrMargin} displaySizeOrMargin={displaySizeOrMargin} value={displaySizeOrMargin == 'Margin' ? $margin : $size} onChangeValue={newValue => size.set(displaySizeOrMargin == 'Margin' ? getSize(newValue, $leverage) : newValue)} isSecondaryColor={!$isLong} placeholder={`0.0 ${$selectedAsset}`} isInvalid={$maxSize && $size > formatForDisplay($maxSize) * 1} />
+				<DDInput label='Size' setDisplaySizeOrMargin={setDisplaySizeOrMargin} displaySizeOrMargin={displaySizeOrMargin} value={displaySizeOrMargin == 'Margin' ? ($margin.toFixed(4)) : $size} onChangeValue={newValue => size.set(displaySizeOrMargin == 'Margin' ? getSize(newValue, $leverage) : newValue)} isSecondaryColor={!$isLong} placeholder={`0.0 ${$selectedAsset}`} isInvalid={$maxSize && $size > formatForDisplay($maxSize) * 1} />
 			</div>
 			
 			<div class='slider-container bottom-spacing'>

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -93,6 +93,7 @@ export const trailing30dayVolume = writable();
 export const currentFeeRebate = writable();
 export const feeRebateFromVolume = writable();
 export const feeRebateFromStaking = writable();
+export const feeRebateFromReferral = writable(0);
 export const totalFeesSaved = writable({});
 export const rebateParams = writable([]);
 


### PR DESCRIPTION
Addressing Issue #24 - Added referral fee discount to Fee Discounts modal

In addition, the margin input currently has no restriction on decimal digits, this should limit it to 4, the maximum allowed