### PR TITLE
Added Take-Profit/Stop-Loss modal, Fixed Undefined Margin/Size button 

### DIFF
--- a/src/components/layout/Modals.svelte
+++ b/src/components/layout/Modals.svelte
@@ -15,6 +15,7 @@
 	import UnstakeCAP from '../modals/UnstakeCAP.svelte'
 	import HistoryOrderStatus from '../modals/HistoryOrderStatus.svelte'
 	import Settings from '../modals/Settings.svelte'
+	import AdvancedTPSL from '../modals/AdvancedTPSL.svelte'
 
 </script>
 
@@ -72,4 +73,8 @@
 
 {#if $activeModal && $activeModal.name == 'MarketInfo'}
 <MarketInfo data={$activeModal.data} />
+{/if}
+
+{#if $activeModal && $activeModal.name == 'AdvancedTPSL'}
+<AdvancedTPSL />
 {/if}

--- a/src/components/modals/AdvancedTPSL.svelte
+++ b/src/components/modals/AdvancedTPSL.svelte
@@ -199,10 +199,10 @@ function onBlur() { percentageInput = false; }
         gap: 10px;
     }
     .input-tpsl-width {
-        flex-basis: 65%;
+        flex-basis: 60%;
     }
     .input-gainloss-width {
-        flex-basis: 35%;
+        flex-basis: 40%;
     }
     .bottom-spacing {
 		padding-bottom: 16px;
@@ -225,7 +225,7 @@ function onBlur() { percentageInput = false; }
 		width: 100%;
 		box-sizing: border-box;
 		text-align: right;
-		padding-right: 14px;
+		padding-right: 28px;
 		border-radius: 6px;
 		background-color: var(--layer50);
 		border: 1px solid var(--layer200);
@@ -272,6 +272,24 @@ function onBlur() { percentageInput = false; }
 		letter-spacing: 0.05rem;
 		font-weight: 500;
 	}
+
+    .suffix {
+		position: absolute;
+		background-color: var(--layer50);
+		padding-left: 2px;
+		padding-right: 14px;
+		margin-right: 1px;
+		top: 50%;
+		transform: translateY(-50%);
+		pointer-events: none;
+		white-space: nowrap;
+		right: 0px;
+		display: flex;
+		align-items: center;
+		text-transform: uppercase;
+		letter-spacing: 0.05rem;
+		font-weight: 500;
+	}
     
 
 </style>
@@ -293,6 +311,9 @@ function onBlur() { percentageInput = false; }
                     Gain
                 </label>
                 <input id='Gain' type='number' step="0.0000001" bind:value={displayTPProfit} min="0" max="10000000" maxlength="10" spellcheck="false" placeholder={`0.0`} autocomplete="off" autocorrect="off" inputmode="decimal" lang="en" on:focus={onFocus} on:blur={onBlur} >
+                <label for='Gain' class='suffix'>
+                    %
+                </label>
             </div>
         </div>
     </div>
@@ -316,6 +337,9 @@ function onBlur() { percentageInput = false; }
                     Loss
                 </label>
                 <input id='Loss'  type='number' step="0.0000001" bind:value={displaySLLoss} min="0" max="10000000" maxlength="10" spellcheck="false" placeholder={`0.0`} autocomplete="off" autocorrect="off" inputmode="decimal" lang="en" on:focus={onFocus} on:blur={onBlur} >
+                <label for='Loss' class='suffix'>
+                    %
+                </label>
             </div>
         </div>
     </div>

--- a/src/components/modals/AdvancedTPSL.svelte
+++ b/src/components/modals/AdvancedTPSL.svelte
@@ -1,0 +1,328 @@
+<script>
+	
+	import Modal from './Modal.svelte'
+	import Input from '@components/layout/Input.svelte'
+    import { getUPL } from '@lib/utils'
+    import { formatForDisplay } from '@lib/formatters'
+
+    import {
+		address,
+		allowances,
+		isLong,
+		orderType,
+		selectedAsset,
+		selectedMarket,
+		size,
+		buyingPower,
+		price,
+		hasTPSL,
+		tpPrice,
+		slPrice,
+		leverage,
+		priceAsset,
+		isReduceOnly,
+		margin,
+		sizeInUsd,
+		liquidationPrice,
+		isProtectedOrder,
+		balances,
+		maxSize,
+		prices,
+		submittingOrder
+	} from '@lib/stores'
+
+    let tpPNL
+    let slPNL
+    let tpProfit
+    let slLoss
+    let displayTPProfit
+    let displaySLLoss
+    let invalidTakeProfit = false
+    let invalidStopLoss = false
+    let percentageInput = false
+    let _price
+
+function updatePNLs() {
+
+    let tpPosition = {
+        isLong: $isLong,
+        size: $size,
+        price: _price 
+    }
+
+    let slPosition = {
+        isLong: $isLong,
+        size: $size,
+        price: _price
+    }
+
+    tpPNL = getUPL(tpPosition, $tpPrice)
+    slPNL = getUPL(slPosition, $slPrice)
+}
+
+function getEstimatedPNL() {
+
+    updatePNLs()
+
+    tpProfit = (tpPNL / $margin) * 100
+    slLoss = (slPNL / $margin) * 100 * -1
+
+
+    if (!percentageInput)
+    {
+        displayTPProfit = formatForDisplay(tpProfit)
+        displaySLLoss = formatForDisplay(slLoss)
+    }
+
+    validateInputs()
+    getTPSLFromGainLoss()
+
+
+}
+
+function validateInputs() {
+
+    if ($isLong)
+    {
+        if (_price > $tpPrice && $tpPrice > 0)
+        {
+            invalidTakeProfit = true
+        }
+        else
+        {
+            invalidTakeProfit = false
+        }
+
+        if (_price < $slPrice && $slPrice > 0)
+        {
+            invalidStopLoss = true
+        }
+        else
+        {
+            invalidStopLoss = false
+        }
+
+    }
+    else
+    {
+        if (_price < $tpPrice && $tpPrice > 0)
+        {
+            invalidTakeProfit = true
+        }
+        else
+        {
+            invalidTakeProfit = false
+        }
+
+        if (_price > $slPrice && $slPrice > 0)
+        {
+            invalidStopLoss = true
+        }
+        else
+        {
+            invalidStopLoss = false
+        }
+    }
+
+}
+
+function getTPSLFromGainLoss() {
+
+    console.log("percentageinput", percentageInput)
+    if (percentageInput)
+    {
+        let estimatedTakeProfit
+        let estimatedStopLoss
+
+        if ($isLong)
+        {
+            estimatedTakeProfit = _price + (_price * ((displayTPProfit / 100) / $leverage))
+            estimatedStopLoss = _price - (_price * ((displaySLLoss / 100) / $leverage))
+        }
+        else
+        {
+            estimatedTakeProfit = _price - (_price * ((displayTPProfit / 100) / $leverage))
+            estimatedStopLoss = _price + (_price * ((displaySLLoss / 100) / $leverage))
+        }
+
+        tpPNL = ($margin / estimatedTakeProfit) * 100
+        slPNL = ($margin / estimatedStopLoss) * 100 * -1 
+
+        tpPrice.set(formatForDisplay(estimatedTakeProfit))
+        slPrice.set(formatForDisplay(estimatedStopLoss))
+
+        updatePNLs()
+        validateInputs()
+    }
+}
+
+function getPriceType() {
+    if ($orderType == 0)
+    {
+        _price = $prices[$selectedMarket]
+    }
+    else
+    {
+        _price = $price
+    }
+}
+
+$: getEstimatedPNL($tpPrice, $slPrice, $orderType)
+$: getTPSLFromGainLoss(displayTPProfit, displaySLLoss, $orderType)
+$: getPriceType($orderType)
+$: validateInputs($orderType)
+
+function onFocus() { percentageInput = true; }
+function onBlur() { percentageInput = false; }
+
+</script>
+
+<style>
+
+    .container {
+
+    }
+    .note {
+		line-height: 1.458;
+		color: var(--text1-alt);
+		font-size: 80%;
+        padding-top: 16px;
+	}
+    .warning {
+		line-height: 1.458;
+		color: var(--secondary);
+		font-size: 80%;
+	}
+    .input-container {
+        display: flex;
+        flex-direction: row;
+        gap: 10px;
+    }
+    .input-tpsl-width {
+        flex-basis: 65%;
+    }
+    .input-gainloss-width {
+        flex-basis: 35%;
+    }
+    .bottom-spacing {
+		padding-bottom: 16px;
+	}
+	.top-spacing {
+		padding-top: 16px;
+	}
+    .border-bottom {
+        border-bottom: 1px solid var(--layer1-hover);
+    }
+
+    .input-wrapper {
+		height: 42px;
+		position: relative;
+		font-size: 85%;
+		
+	}
+	input {
+		height: 100%;
+		width: 100%;
+		box-sizing: border-box;
+		text-align: right;
+		padding-right: 14px;
+		border-radius: 6px;
+		background-color: var(--layer50);
+		border: 1px solid var(--layer200);
+		caret-color: var(--primary);
+		font-size: inherit;
+		font-weight: 600;
+		/*transition: padding 200ms ease-in-out;*/
+	}
+	input:hover {
+		border-color: var(--layer300);
+	}
+	input:focus {
+		border-color: var(--primary);
+	}
+	input:disabled {
+		color: var(--text200);
+	}	
+
+	input::placeholder {
+	  color: var(--text500);
+	  opacity: 1;
+	}
+	input::-ms-input-placeholder{
+	  color: var(--text500);
+	}
+	input:-ms-input-placeholder {
+	  color: var(--text500);
+	}
+
+    .prefix {
+		position: absolute;
+		background-color: var(--layer50);
+		padding-left: 14px;
+		padding-right: 14px;
+		margin-left: 1px;
+		top: 50%;
+		transform: translateY(-50%);
+		pointer-events: none;
+		white-space: nowrap;
+		left: 0px;
+		display: flex;
+		align-items: center;
+		text-transform: uppercase;
+		letter-spacing: 0.05rem;
+		font-weight: 500;
+	}
+    
+
+</style>
+
+<Modal title='Take-Profit/Stop-Loss' width={450} doneButton={true}>
+<div class='container'>
+    {#if ($isLong && invalidTakeProfit)}
+    <div class='warning red bottom-spacing'>The Take-Profit level must be <strong>higher</strong> than the {#if ($orderType == 0)}<span>current price</span>{:else if ($orderType == 1)}Limit Price{:else if ($orderType == 2)}Stop Price{/if}.</div>
+    {:else if (!$isLong && invalidTakeProfit)}
+    <div class='warning red bottom-spacing'>The Take-Profit level must be <strong>lower</strong> than the {#if ($orderType == 0)}<span>current price</span>{:else if ($orderType == 1)}Limit Price{:else if ($orderType == 2)}Stop Price{/if}.</div>
+    {/if}
+    <div class='input-container'>
+        <div class='input-tpsl-width'>
+            <Input label='Take Profit' bind:value={$tpPrice} isInvalid={invalidTakeProfit}/>
+        </div>
+        <div class='input-gainloss-width'>
+            <div class='input-wrapper' on:click|stopPropagation>
+                <label for='Gain' class='prefix'>
+                    Gain
+                </label>
+                <input id='Gain' type='number' step="0.0000001" bind:value={displayTPProfit} min="0" max="10000000" maxlength="10" spellcheck="false" placeholder={`0.0`} autocomplete="off" autocorrect="off" inputmode="decimal" lang="en" on:focus={onFocus} on:blur={onBlur} >
+            </div>
+        </div>
+    </div>
+    {#if ($tpPrice > 0)}
+    <div class='note bottom-spacing border-bottom'>When the price hits {$tpPrice} your position will automatically close, with an estimated PNL of <strong>{formatForDisplay(tpPNL)}</strong> and a profit of <strong>{displayTPProfit}%</strong></div>
+    {:else}
+    <div class='note bottom-spacing border-bottom'>There is no Take-Profit level set up.</div>
+    {/if}
+    {#if ($isLong && invalidStopLoss)}
+    <div class='warning red top-spacing'>The Stop-Loss level must be <strong>lower</strong> than the {#if ($orderType == 0)}<span>current price</span>{:else if ($orderType == 1)}Limit Price{:else if ($orderType == 2)}Stop Price{/if}.</div>
+    {:else if (!$isLong && invalidStopLoss)}
+    <div class='warning red top-spacing'>The Stop-Loss level must be <strong>higher</strong> than the {#if ($orderType == 0)}<span>current price</span>{:else if ($orderType == 1)}Limit Price{:else if ($orderType == 2)}Stop Price{/if}.</div>
+    {/if}
+    <div class='input-container top-spacing'>
+        <div class='input-tpsl-width'>
+            <Input label='Stop Loss' bind:value={$slPrice} isInvalid={invalidStopLoss}/>
+        </div>
+        <div class='input-gainloss-width'>
+            <div class='input-wrapper' on:click|stopPropagation>
+                <label for='Loss' class='prefix'>
+                    Loss
+                </label>
+                <input id='Loss'  type='number' step="0.0000001" bind:value={displaySLLoss} min="0" max="10000000" maxlength="10" spellcheck="false" placeholder={`0.0`} autocomplete="off" autocorrect="off" inputmode="decimal" lang="en" on:focus={onFocus} on:blur={onBlur} >
+            </div>
+        </div>
+    </div>
+    {#if ($slPrice > 0)}
+    <div class='note'>When the price hits {$slPrice} your position will automatically close, with an estimated PNL of <strong>{formatForDisplay(slPNL)}</strong> and a loss of <strong>{displaySLLoss}%</strong></div>
+    {:else}
+    <div class='note'>There is no Stop-Loss level set up.</div>
+    {/if}
+</div>
+</Modal>

--- a/src/components/trade/order/NewOrder.svelte
+++ b/src/components/trade/order/NewOrder.svelte
@@ -50,11 +50,11 @@
 	import { submitOrder } from '@api/orders'
 
 	let showAdvanced = false;
-	let displaySizeOrMargin = 'Size';
+	let displaySizeOrMargin;
 
 	onMount(() => {
 		displaySizeOrMargin = getUserSetting('displaySizeOrMargin');
-		if (!displaySizeOrMargin) saveUserSetting('displaySizeOrMargin', 'Size')
+		if (!displaySizeOrMargin) setDisplaySizeOrMargin('Margin')
 	})
 
 	function setDisplaySizeOrMargin(sizeOrMargin) {
@@ -258,6 +258,20 @@
 		color: var(--error);
 		font-size: 80%;
 	}
+	.tpsl-header {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	.tpsl-help-button {
+		padding: 6px 12px;
+		background-color: var(--layer100);
+		border-radius: var(--base-radius);
+	}
+	.tpsl-help-button:hover {
+		background-color: var(--layer200);
+	}
+
 </style>
 
 <div class='new-order'>
@@ -323,13 +337,15 @@
 			{#if showAdvanced}
 			<div class='bottom-spacing'>
 
-				<div class='semi-padding-bottom row'>
+				<div class='semi-padding-bottom row tpsl-header'>
 					<Checkbox label='Take-Profit / Stop-Loss' bind:value={$hasTPSL} isSecondaryColor={!$isLong} />
+					{#if $hasTPSL}
+					<a class='tpsl-help-button' on:click|stopPropagation={() => {showModal('AdvancedTPSL')}}>Help</a>
+					{/if}
 				</div>
 
 				{#if $hasTPSL}
 					<div>
-
 						<div class='semi-padding-bottom'>
 							<Input label='TP Price' bind:value={$tpPrice} isSecondaryColor={!$isLong} />
 						</div>

--- a/src/components/trade/order/NewOrder.svelte
+++ b/src/components/trade/order/NewOrder.svelte
@@ -340,7 +340,7 @@
 				<div class='semi-padding-bottom row tpsl-header'>
 					<Checkbox label='Take-Profit / Stop-Loss' bind:value={$hasTPSL} isSecondaryColor={!$isLong} />
 					{#if $hasTPSL}
-					<a class='tpsl-help-button' on:click|stopPropagation={() => {showModal('AdvancedTPSL')}}>Help</a>
+					<a class='tpsl-help-button' on:click|stopPropagation={() => {showModal('AdvancedTPSL')}}>Details</a>
 					{/if}
 				</div>
 


### PR DESCRIPTION
Added a modal to allow users to set their Take-Profit and Stop-Loss levels by Gain/Loss percentage, along with clear instructions. Addresses issue #17 

Margin/Size button would show as Undefined for a first time user, now we set it to Margin on mount if we can't find the setting locally.