### PR TITLE
Fixed numbers below 1 needing a manually typed 0

### DIFF
--- a/src/components/layout/DropdownInput.svelte
+++ b/src/components/layout/DropdownInput.svelte
@@ -27,9 +27,12 @@
 
 	}
 
-	function valueChecker(number) {
+	function valueChecker() {
 
-		value = Number(parseFloat(number).toFixed(7))
+		if (Number(parseFloat(value)) > 0)
+		{
+			value = Number(parseFloat(value).toFixed(7))
+		}
 		
 		if (value > 10000000)
 		{

--- a/src/components/layout/Input.svelte
+++ b/src/components/layout/Input.svelte
@@ -18,10 +18,13 @@
 	export let isHighlighted = false;
 	export let isInvalid = false;
 
-	function valueChecker(number) {
+	function valueChecker() {
 
-		value = Number(parseFloat(number).toFixed(7))
-		
+		if (Number(parseFloat(value)) > 0)
+		{
+			value = Number(parseFloat(value).toFixed(7))
+		}
+
 		if (value > 10000000)
 		{
 			value = 10000000


### PR DESCRIPTION
Entering numbers below 1 required the user to manually type a zero first. Now the user is able to type something like ".250" and it will work as expected.