### PR TITLE
fix: suppress MetaMask rejection errors when approving CAP

### DIFF
--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -42,6 +42,8 @@ const ERROR_STRINGS = {
 export function parseError(e) {
 	console.log('e', typeof(e), e);
 	if (!e) return DEFAULT_ERROR;
+	// MetaMask / EIP-1193 user rejection error code
+	if (e.code === 4001 || e.code === 'ACTION_REJECTED') return null;
 	if (typeof(e) == 'string') return e;
 	let error_string = '';
 	if (e.data && e.data.message) {


### PR DESCRIPTION
## Fix: Suppress MetaMask rejection errors when approving CAP

### Issue
When a user clicks 'Approve CAP' on the Stake pane and then cancels or rejects the MetaMask transaction, an error toast is displayed. This is confusing UX — the app should simply wait and not show an error when the user rejects the wallet transaction.

### Fix
Added explicit handling for EIP-1193 / MetaMask user rejection error codes in `parseError()` (`src/lib/errors.js`):

- `e.code === 4001` — standard MetaMask rejection code
- `e.code === 'ACTION_REJECTED'` — EIP-1193 rejection code used by some wallets

When either code is detected, `parseError()` returns `null`, which causes `showError()` to return early without showing an error toast.

Note: `ERROR_STRINGS` already maps 'user denied' and 'user rejected' strings to `null`, but the explicit `e.code` check covers additional cases where the error message format varies by wallet.

### Testing
- Build verified: `npm run build` passes (bundle created in 27.7s)
- No existing test suite for this file

### Related
Fixes capofficial/client#32