### PR TITLE
feat: show current liquidation price in EditMargin modal

### DIFF
--- a/src/components/modals/EditMargin.svelte
+++ b/src/components/modals/EditMargin.svelte
@@ -152,6 +152,10 @@
 			</div>
 
 			<div class='row'>
+				<LabelValue label='Current Liq. Price' value={`${formatForDisplay(data.position.liqprice) || "-"}`} />
+			</div>
+
+			<div class='row'>
 				<LabelValue label='New Liq. Price' value={`${formatForDisplay(newLiqPrice) || "-"}`} />
 			</div>
 


### PR DESCRIPTION
## Summary

Adds display of the current liquidation price in the Add/Remove Margin modal, alongside the existing new liquidation price calculation.

**Before:** Only the new (projected) liquidation price was shown after adjusting margin.
**After:** Both the current and new liquidation prices are shown, giving users full clarity on how their margin change affects their liquidation risk.

## Changes

- `src/components/modals/EditMargin.svelte`: Added a new `LabelValue` row displaying `Current Liq. Price` using the existing `data.position.liqprice` value.

## Testing

The component already computes `newLiqPrice` dynamically via `calculateNewLiquidationPrice()`. The current liq price (`data.position.liqprice`) is already available in scope — no new computations needed.

## Related

Fixes #4