### PR TITLE
fix: format size to close to avoid floating point precision errors

### DIFF
--- a/src/components/modals/ClosePosition.svelte
+++ b/src/components/modals/ClosePosition.svelte
@@ -96,7 +96,7 @@
 			</div>
 
 			<div class='row'>
-				<LabelValue label='Max' value={`${formatForDisplay(data.size)} ${data.asset}`} on:click={() => amount = data.size} isClickable={true} />
+				<LabelValue label='Max' value={`${formatForDisplay(data.size)} ${data.asset}`} on:click={() => amount = formatForDisplay(data.size)} isClickable={true} />
 			</div>
 
 			<div class='row'>


### PR DESCRIPTION
## Summary

When clicking 'Max' to close a full position, the raw position size could have floating point artifacts like `9.1138999999` instead of the properly rounded `9.1139`, causing the order to be rejected by the backend with an error like:

> The two nearest valid values are 9.1138999 and 9.1139.

This fix applies `formatForDisplay()` when setting the amount from Max, ensuring the input always contains a properly formatted value.

## Changes

- `src/components/modals/ClosePosition.svelte`: Changed `on:click={() => amount = data.size}` to `on:click={() => amount = formatForDisplay(data.size)}`

## Testing

1. Open a position on the CAP trading platform
2. Click 'Close Position'
3. Click 'Max' to fill the size with the full position amount
4. Verify the input shows a properly formatted number (e.g., `9.1139` not `9.1138999999`)
5. Submit the close order — it should succeed without precision errors

## Fixes

Fixes capofficial/client#11