### PR TITLE
Fix pool performance metrics display

### DIFF
--- a/src/components/pool/Pools.svelte
+++ b/src/components/pool/Pools.svelte
@@ -29,10 +29,36 @@
 
 	let feeAPY = {};
 
+	const MONTHLY_FEES = {
+		ETH: 95,
+		USDC: 100000
+	};
+
+	function asNumber(value) {
+		const number = value * 1;
+		return Number.isFinite(number) ? number : 0;
+	}
+
+	function formatPercent(value) {
+		const number = asNumber(value);
+		return number ? `${formatForDisplay(number)}%` : '-';
+	}
+
+	function getTraderUplImpact(asset) {
+		const balance = asNumber($poolBalances[asset]);
+		if (!balance) return 0;
+		// Positive trader UP/L is owed by the pool, so it reduces pool performance.
+		return -asNumber($globalUPLs[asset]) / balance * 100;
+	}
+
 	function setFeeAPYs(_balances) {
 		if (!_balances) return;
-		if (_balances['ETH']) feeAPY['ETH'] = 100 * 95 * 12 / _balances['ETH']; // Approx 95 ETH per month in fees
-		if (_balances['USDC']) feeAPY['USDC'] = 100 * 100000 * 12 / _balances['USDC']; // Approx 100,000 USDC per month in fees
+		feeAPY = assets.reduce((apys, asset) => {
+			const balance = asNumber(_balances[asset]);
+			const monthlyFees = asNumber(MONTHLY_FEES[asset]);
+			apys[asset] = balance && monthlyFees ? 100 * monthlyFees * 12 / balance : 0;
+			return apys;
+		}, {});
 	}
 
 	$: setFeeAPYs($poolBalances);
@@ -165,10 +191,10 @@
 			<div class='row'>
 				<div class='cell la'><img src={`/asset-logos/${asset}.svg`} /> {asset}</div>
 				<div class='cell'><span>{numberWithCommas($poolBalances[asset]) || 0}<br/><span class='grayed'>${formatForDisplay(getAmountInUsd(asset, $poolBalances[asset], $prices))}</span></span></div>
-				<div class='cell'>{formatForDisplay(feeAPY[asset])}%</div>
-				<div class='cell'>30%+</div>
-				<div class='cell'>{numberWithCommas($globalUPLs[asset])}</div>
-				<div class='cell'>{numberWithCommas($bufferBalances[asset])}</div>
+				<div class='cell'>{formatPercent(feeAPY[asset])}</div>
+				<div class='cell'>{formatPercent(asNumber(feeAPY[asset]) + getTraderUplImpact(asset))}</div>
+				<div class='cell'><span>{numberWithCommas($globalUPLs[asset])}<br/><span class='grayed'>${formatForDisplay(getAmountInUsd(asset, $globalUPLs[asset], $prices))}</span></span></div>
+				<div class='cell'><span>{numberWithCommas($bufferBalances[asset])}<br/><span class='grayed'>${formatForDisplay(getAmountInUsd(asset, $bufferBalances[asset], $prices))}</span></span></div>
 				<div class='cell highlighted'><span>{numberWithCommas($poolStakes[asset]) || 0}<br><span class='grayed'>${getAmountInUsd(asset, $poolStakes[asset], $prices)}</span></span></div>
 				<div class='cell highlighted'>{$poolBalances[asset] == 0 ? 'N/A' : formatForDisplay(($poolStakes[asset])/$poolBalances[asset]  *100 )+ '%'}</div>
 			</div>


### PR DESCRIPTION
## Summary
- Replaces the hard-coded `30%+` pool performance display with a derived performance value per asset.
- Keeps fee APY derived from the documented monthly fee assumptions, but centralizes the fee constants and guards non-numeric/zero balances.
- Adds USD sub-values for trader UP/L and buffer balances so the table no longer mixes raw asset units with unexplained metrics.

## Root cause
The pool table had one dynamic yield column and one static placeholder: `30%+` was rendered for every asset regardless of pool balance or global trader UP/L. That made the displayed pool performance nonsensical and unable to react to the actual pool state shown in the adjacent columns.

## Reproduction / failing case
Open the Pool page with any non-zero pool balance and a non-zero global UP/L. Before this change, the pool performance column still displayed `30%+` for both ETH and USDC, so the value did not change when the pool balance or trader UP/L changed.

## Changed files / scope
- `src/components/pool/Pools.svelte` only.
- No route, contract, wallet, or store changes.

## Implementation notes
- `MONTHLY_FEES` keeps the existing fee assumptions: ~95 ETH/month and ~100,000 USDC/month.
- `feeAPY` is recomputed for each supported pool asset and falls back to `0` when data is missing.
- Pool performance is displayed as `feeAPY - traderUPL / poolBalance * 100`, because positive trader UP/L is owed by the pool and reduces pool-side performance.
- Missing/zero balances render `-` rather than `NaN%`/`Infinity%`.

## Validation
- `NODE_OPTIONS=--max-old-space-size=2048 npm run build` ✅
  - Build completed and created `build/bundle.dd73831.js`.
  - Existing Svelte/Rollup warnings are still present and are unrelated to this one-file pool table change.

## Edge cases covered
- Zero or missing pool balance.
- Missing/non-numeric fee, UP/L, or balance values.
- Assets without a monthly fee constant.
- Positive and negative trader UP/L values.

## Risk / compatibility
Low risk: this is a display-only change inside the Pool table. It preserves the existing monthly fee assumptions and does not modify state, transactions, stores, or contract calls.

## Acceptance checklist
- [x] Pool performance is no longer a hard-coded placeholder.
- [x] Metrics are derived from the same per-asset pool state shown in the table.
- [x] Invalid arithmetic is guarded so users do not see `NaN%` or `Infinity%`.
- [x] Minimal one-file change with a successful targeted production build.

Closes #6
