### PR TITLE
feat: add first-run welcome guide

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,14 +11,24 @@
 	import { USD_CONVERSION_MARKETS } from '@lib/config'
 	import { checkCountry, loadRoute, catchLinks, navigateTo } from '@lib/routing'
 	import { component, address, pageName, countryDisallowed } from '@lib/stores'
-	import { hidePopoversOnKeydown, hidePopoversOnClick } from '@lib/ui'
-	import { runAndInterval, hashString, getChainData } from '@lib/utils'
+	import { hidePopoversOnKeydown, hidePopoversOnClick, showModal } from '@lib/ui'
+	import { runAndInterval, hashString, getChainData, getUserSetting } from '@lib/utils'
 
 	import { getUserAssetBalances } from '@api/assets'
 	import { listenToEvents } from '@api/listener'
 	import { getMarketPrices } from '@api/prices'
 
 	let interval1;
+	let checkedWelcome = false;
+
+	function maybeShowWelcome() {
+		if (checkedWelcome || $pageName == 'Home' || getUserSetting('hasSeenWelcome')) return;
+
+		checkedWelcome = true;
+		setTimeout(() => {
+			if (!getUserSetting('hasSeenWelcome')) showModal('Welcome');
+		}, 500);
+	}
 
 	onMount(async () => {
 
@@ -39,6 +49,7 @@
 
 	// Listener
 	$: listenToEvents($address);
+	$: if ($pageName) maybeShowWelcome();
 
 </script>
 

--- a/src/components/header/Nav.svelte
+++ b/src/components/header/Nav.svelte
@@ -5,10 +5,16 @@
 	import Rewards from './Rewards.svelte'
 
 	import { pageName, showMobileNav } from '@lib/stores'
-	import { TROPHY_ICON, BULLET_LIST_ICON } from '@lib/icons'
+	import { TROPHY_ICON, BULLET_LIST_ICON, BOOK_ICON } from '@lib/icons'
+	import { showModal } from '@lib/ui'
 
 	function toggleMobileNav() {
 		showMobileNav.set(!$showMobileNav);
+	}
+
+	function openGuide() {
+		showMobileNav.set(false);
+		showModal('Welcome');
 	}
 </script>
 
@@ -27,18 +33,25 @@
 		gap: 8px;
 	}
 
-	a {
+	a,
+	button.nav-action {
 		color: var(--text0);
 		text-decoration: none;
 		padding: 8px 12px;
 		border-radius: var(--base-radius);
 		transition: all 100ms ease-in-out;
 		font-weight: 500;
+		border: none;
+		background: transparent;
+		font: inherit;
+		cursor: pointer;
 	}
-	a:hover  {
+	a:hover,
+	button.nav-action:hover  {
 		background-color: var(--layer1);
 	}
-	 a.active {
+	 a.active,
+	 button.nav-action.active {
 	 	color: var(--primary);
 		background-color: var(--primary-highlighted);
 	}
@@ -55,6 +68,16 @@
 	a.leaderboard-link :global(svg) {
 		fill: currentColor;
 		height: 18px;
+	}
+
+	button.guide-link {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+	button.guide-link :global(svg) {
+		fill: currentColor;
+		height: 16px;
 	}
 
 	.mobile-nav {
@@ -78,7 +101,8 @@
 		fill: inherit;
 	}
 
-	.mobile-nav a {
+	.mobile-nav a,
+	.mobile-nav button.nav-action {
 		display: none;
 		padding: 10px 8px;
 	}
@@ -104,7 +128,8 @@
 			bottom: 0;
 			width: 100%;
 		}
-		.mobile-nav a {
+		.mobile-nav a,
+		.mobile-nav button.nav-action {
 			display: block;
 			font-size: 120%;
 			padding: 16px 8px;
@@ -121,6 +146,7 @@
 	<a class:active={$pageName == 'Trade'} href='/trade'>Trade</a>
 	<a class:active={$pageName == 'Pool'} href='/pool'>Pool</a>
 	<a class:active={$pageName == 'Stake'} href='/stake'>Stake</a>
+	<button type='button' class='nav-action guide-link' on:click|stopPropagation={openGuide}>{@html BOOK_ICON}<span>Guide</span></button>
 	<a on:click|stopPropagation={toggleMobileNav} class:active={$showMobileNav}>…</a>
 </div>
 
@@ -132,6 +158,7 @@
 	<a on:click={toggleMobileNav} href='/trade'>Trade</a>
 	<a on:click={toggleMobileNav} href='/pool'>Pool</a>
 	<a on:click={toggleMobileNav} href='/stake'>Stake</a>
+	<button type='button' class='nav-action' on:click|stopPropagation={openGuide}>Guide</button>
 	<a on:click={toggleMobileNav} href='https://docs.cap.io' target='_blank' class='display-desktop'>Docs</a>
 </div>
 {/if}

--- a/src/components/layout/Modals.svelte
+++ b/src/components/layout/Modals.svelte
@@ -14,11 +14,16 @@
 	import UnstakeCAP from '../modals/UnstakeCAP.svelte'
 	import HistoryOrderStatus from '../modals/HistoryOrderStatus.svelte'
 	import Settings from '../modals/Settings.svelte'
+	import Welcome from '../modals/Welcome.svelte'
 
 </script>
 
 {#if $activeModal && $activeModal.name == 'Settings'}
 <Settings />
+{/if}
+
+{#if $activeModal && $activeModal.name == 'Welcome'}
+<Welcome />
 {/if}
 
 {#if $activeModal && $activeModal.name == 'AssetSelect'}

--- a/src/components/modals/Modal.svelte
+++ b/src/components/modals/Modal.svelte
@@ -43,6 +43,7 @@
 	.modal {
 		width: var(--modal-width);
 		max-width: calc(100vw - (var(--base-padding) * 2));
+		box-sizing: border-box;
 		border-radius: var(--base-radius);
 		background-color: var(--layer25);
 		border: 1px solid var(--layer200);

--- a/src/components/modals/Modal.svelte
+++ b/src/components/modals/Modal.svelte
@@ -42,6 +42,7 @@
 
 	.modal {
 		width: var(--modal-width);
+		max-width: calc(100vw - (var(--base-padding) * 2));
 		border-radius: var(--base-radius);
 		background-color: var(--layer25);
 		border: 1px solid var(--layer200);

--- a/src/components/modals/Welcome.svelte
+++ b/src/components/modals/Welcome.svelte
@@ -1,0 +1,234 @@
+<script>
+	import Modal from './Modal.svelte'
+	import { BOOK_ICON, CHECKMARK_CIRCLE_ICON, INFO_ICON_CIRCLE } from '@lib/icons'
+	import { hideModal } from '@lib/ui'
+	import { navigateTo } from '@lib/routing'
+	import { saveUserSetting } from '@lib/utils'
+
+	const bridgeUrl = 'https://bridge.arbitrum.io/';
+	const docsUrl = 'https://docs.cap.io';
+
+	let innerWidth = 640;
+	$: modalWidth = innerWidth <= 600 ? 280 : 640;
+
+	function dismissWelcome() {
+		saveUserSetting('hasSeenWelcome', true);
+		hideModal();
+	}
+
+	function remindLater() {
+		hideModal();
+	}
+
+	function goTo(path) {
+		dismissWelcome();
+		navigateTo(path);
+	}
+</script>
+
+<style>
+	.welcome {
+		padding: var(--base-padding);
+	}
+
+	.lede {
+		color: var(--text200);
+		line-height: 1.45;
+		margin-bottom: var(--base-padding);
+	}
+
+	.section {
+		padding: var(--base-padding) 0;
+		border-top: 1px solid var(--layer100);
+	}
+	.section:first-of-type {
+		border-top: none;
+		padding-top: 0;
+	}
+
+	.section-title {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-weight: 600;
+		margin-bottom: 12px;
+	}
+	.section-title :global(svg) {
+		width: 17px;
+		height: 17px;
+		fill: var(--primary);
+	}
+
+	.steps {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 12px;
+	}
+
+	.step {
+		border: 1px solid var(--layer100);
+		border-radius: var(--base-radius);
+		padding: 14px;
+		background-color: var(--layer50);
+		min-height: 112px;
+	}
+	.step .label {
+		color: var(--primary);
+		font-size: 12px;
+		font-weight: 600;
+		letter-spacing: 0;
+		text-transform: uppercase;
+		margin-bottom: 8px;
+	}
+	.step .copy {
+		color: var(--text200);
+		font-size: 14px;
+		line-height: 1.38;
+	}
+
+	.bridge {
+		display: grid;
+		grid-template-columns: 1.2fr 1fr;
+		gap: 12px;
+		align-items: stretch;
+	}
+
+	.bridge-copy {
+		color: var(--text200);
+		line-height: 1.45;
+	}
+
+	.checklist {
+		border: 1px solid var(--layer100);
+		border-radius: var(--base-radius);
+		padding: 14px;
+		background-color: var(--layer50);
+	}
+	.check {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		color: var(--text200);
+		font-size: 14px;
+		line-height: 1.35;
+		margin-bottom: 10px;
+	}
+	.check:last-child {
+		margin-bottom: 0;
+	}
+	.check :global(svg) {
+		flex: 0 0 auto;
+		width: 16px;
+		height: 16px;
+		fill: var(--primary);
+		margin-top: 1px;
+	}
+
+	.actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 10px;
+		padding-top: var(--base-padding);
+		border-top: 1px solid var(--layer100);
+	}
+
+	button,
+	a.button {
+		height: 42px;
+		border-radius: var(--base-radius);
+		padding: 0 16px;
+		font-weight: 600;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		text-decoration: none;
+	}
+	button.primary,
+	a.button.primary {
+		color: var(--primary-darkest);
+		background-color: var(--primary);
+	}
+	button.secondary,
+	a.button.secondary {
+		color: var(--text0);
+		background-color: var(--layer100);
+	}
+	button.ghost {
+		color: var(--text300);
+		background-color: transparent;
+	}
+	button:hover,
+	a.button:hover {
+		opacity: 0.9;
+	}
+
+	@media all and (max-width: 600px) {
+		.welcome {
+			padding: 16px;
+		}
+		.steps,
+		.bridge {
+			grid-template-columns: 1fr;
+		}
+		.step {
+			min-height: 0;
+		}
+		.actions {
+			flex-direction: column;
+		}
+		button,
+		a.button {
+			width: 100%;
+		}
+	}
+</style>
+
+<svelte:window bind:innerWidth />
+
+<Modal title='Welcome to CAP' width={modalWidth}>
+	<div class='welcome'>
+		<div class='lede'>
+			CAP is a decentralized perpetuals trading dashboard on Arbitrum. Use it to trade supported markets, provide liquidity through pools, and stake CAP while keeping custody in your wallet.
+		</div>
+
+		<div class='section'>
+			<div class='section-title'>{@html BOOK_ICON}<span>Start with the main flows</span></div>
+			<div class='steps'>
+				<div class='step'>
+					<div class='label'>1. Fund</div>
+					<div class='copy'>Connect a wallet and bring trading collateral such as USDC or ETH to Arbitrum before placing orders.</div>
+				</div>
+				<div class='step'>
+					<div class='label'>2. Trade</div>
+					<div class='copy'>Choose a market, collateral, leverage, and size, then review fees, take-profit, stop-loss, and liquidation risk.</div>
+				</div>
+				<div class='step'>
+					<div class='label'>3. Earn</div>
+					<div class='copy'>Pool and Stake pages let liquidity providers and CAP stakers manage deposits, withdrawals, and rewards.</div>
+				</div>
+			</div>
+		</div>
+
+		<div class='section'>
+			<div class='section-title'>{@html INFO_ICON_CIRCLE}<span>Bridge funds to Arbitrum</span></div>
+			<div class='bridge'>
+				<div class='bridge-copy'>
+					If your wallet funds are on another network, bridge them to Arbitrum first. Use the official Arbitrum bridge, then return to CAP and confirm the connected network before trading.
+				</div>
+				<div class='checklist'>
+					<div class='check'>{@html CHECKMARK_CIRCLE_ICON}<span>Use the same wallet address on both networks.</span></div>
+					<div class='check'>{@html CHECKMARK_CIRCLE_ICON}<span>Keep ETH on Arbitrum for gas.</span></div>
+					<div class='check'>{@html CHECKMARK_CIRCLE_ICON}<span>Wait for the bridge transaction to finish before placing an order.</span></div>
+				</div>
+			</div>
+		</div>
+
+		<div class='actions'>
+			<button class='primary' type='button' on:click|stopPropagation={() => goTo('/trade')}>Start trading</button>
+			<a class='button secondary' href={bridgeUrl} target='_blank' rel='noreferrer'>Open bridge</a>
+			<a class='button secondary' href={docsUrl} target='_blank' rel='noreferrer'>Read docs</a>
+			<button class='secondary' type='button' on:click|stopPropagation={dismissWelcome}>Got it</button>
+			<button class='ghost' type='button' on:click|stopPropagation={remindLater}>Remind me next time</button>
+		</div>
+	</div>
+</Modal>

--- a/src/components/modals/Welcome.svelte
+++ b/src/components/modals/Welcome.svelte
@@ -8,9 +8,6 @@
 	const bridgeUrl = 'https://bridge.arbitrum.io/';
 	const docsUrl = 'https://docs.cap.io';
 
-	let innerWidth = 640;
-	$: modalWidth = innerWidth <= 600 ? 280 : 640;
-
 	function dismissWelcome() {
 		saveUserSetting('hasSeenWelcome', true);
 		hideModal();
@@ -183,9 +180,7 @@
 	}
 </style>
 
-<svelte:window bind:innerWidth />
-
-<Modal title='Welcome to CAP' width={modalWidth}>
+<Modal title='Welcome to CAP' width={640}>
 	<div class='welcome'>
 		<div class='lede'>
 			CAP is a decentralized perpetuals trading dashboard on Arbitrum. Use it to trade supported markets, provide liquidity through pools, and stake CAP while keeping custody in your wallet.


### PR DESCRIPTION
Closes #13

## Summary
- Add a first-run Welcome modal for non-home dashboard pages with a short CAP overview, core trading/pool/staking flow guidance, and Arbitrum bridge instructions.
- Persist dismissal in existing `userSettings` as `hasSeenWelcome`, while keeping a "Remind me next time" option for users who want to see it again.
- Add a Guide entry to the desktop and mobile nav so users can reopen onboarding at any time.
- Constrain modal width on narrow screens so the guide stays readable on mobile.

## Validation
- `npm run build`
- Headless Chrome desktop screenshot: first `/trade` visit opens the Welcome modal.
- Headless Chrome narrow viewport screenshot: Welcome modal fits without horizontal clipping.

Note: the build still reports existing Svelte accessibility/unused CSS and dependency warnings from the current codebase; no new blocking build errors were introduced.
