### PR TITLE
🐛 Fix: Approve CAP error shows before wallet confirmation

### DIFF
--- a/src/api/assets.js
+++ b/src/api/assets.js
@@ -71,6 +71,11 @@ export async function approveAsset(assetLabel, spenderName) {
 			return true;
 		}
 	} catch(e) {
+		const msg = (e?.message || '').toLowerCase();
+		// Silent fail for user-rejected transactions (MetaMask cancel etc.)
+		if (msg.includes('user denied') || msg.includes('user rejected') || msg.includes('user cancelled')) {
+			return false;
+		}
 		showError(e);
 	}
 }

--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -35,7 +35,16 @@
 	}
 
 	async function _approveAsset() {
-		const result = await approveAsset('CAP', 'FundStore');
+		isSubmitting = true;
+		try {
+			const result = await approveAsset('CAP', 'FundStore');
+			if (result) {
+				await checkAllowance();
+			}
+		} catch(e) {
+			// Silent - errors handled in approveAsset
+		}
+		isSubmitting = false;
 	}
 
 	async function getBalance() {
@@ -75,7 +84,7 @@
 
 			<div>
 				{#if $allowances['CAP']?.['FundStore'] * 1 <= amount * 1}
-				<Button noSubmit={true} label={`Approve CAP`} on:click={_approveAsset} />
+				<Button isLoading={isSubmitting} noSubmit={true} label={`Approve CAP`} on:click={_approveAsset} />
 				{:else}
 				<Button isLoading={isSubmitting} label={`Stake`} />
 				{/if}


### PR DESCRIPTION
## Fixes #32

### Problem
When clicking "Approve CAP" on the Stake modal, an error was displayed **before** the wallet (MetaMask) confirmation. This was caused by:

1. **Missing loading state** — The Approve button had no `isSubmitting` state, so users saw no feedback during wallet interaction
2. **No silent handling of user rejection** — When users rejected the MetaMask prompt, the raw error was shown as a modal
3. **No allowance refresh** — After successful approval, the allowance wasn't refreshed immediately

### Changes

**`src/api/assets.js` — `approveAsset()`**
- Added silent handling for `user denied` / `user rejected` / `user cancelled` errors (no error popup when user cancels in MetaMask)

**`src/components/modals/StakeCAP.svelte` — `_approveAsset()`**
- Added `isSubmitting = true` before calling approveAsset
- Added `isSubmitting = false` after completion
- Added allowance refresh (`checkAllowance()`) after successful approval
- Added loading state to the Approve CAP button (`isLoading={isSubmitting}`)

### Testing
1. Open Stake CAP modal
2. Click "Approve CAP" → Button shows loading state
3. Confirm in MetaMask → Allowance updates, "Stake" button appears
4. Click "Approve CAP" → Click Cancel in MetaMask → No error shown, button resets