### PR TITLE
feat: allow typing leverage in modal

### DIFF
--- a/src/components/modals/LeverageSelect.svelte
+++ b/src/components/modals/LeverageSelect.svelte
@@ -1,20 +1,61 @@
 <script>
 	import Modal from './Modal.svelte'
 
-	import { onMount } from 'svelte'
-
 	import Slider from '@components/layout/Slider.svelte'
-
-	import tooltip from '@lib/tooltip'
-	import { formatForDisplay } from '@lib/formatters'
-	import { PENCIL_ICON, RULER_ICON, RULER_FILLED_ICON } from '@lib/icons'
 
 	import { leverage, selectedMarket, selectedMarketInfo } from '@lib/stores'
 	import { saveUserSetting } from '@lib/utils'
 
+	let leverageInput = '';
+	let isEditingInput = false;
+
+	function clampLeverage(value) {
+		const maxLeverage = $selectedMarketInfo?.maxLeverage * 1;
+		const numericValue = value * 1;
+		const currentLeverage = $leverage * 1 || 1;
+
+		if (!maxLeverage || isNaN(numericValue)) return currentLeverage;
+		if (numericValue < 1) return 1;
+		if (numericValue > maxLeverage) return maxLeverage;
+		return Math.round(numericValue);
+	}
+
+	function setLeverageValue(value) {
+		const nextValue = clampLeverage(value);
+		leverage.set(nextValue);
+		leverageInput = `${nextValue}`;
+	}
+
 	function saveLeverage() {
 		if ($leverage == null || $leverage * 1 < 1) return;
 		saveUserSetting(`leverage-${$selectedMarket}`, $leverage);
+	}
+
+	function handleInput(event) {
+		isEditingInput = true;
+		leverageInput = event.currentTarget.value;
+	}
+
+	function commitInput() {
+		isEditingInput = false;
+		if (leverageInput === '') {
+			leverageInput = `${$leverage}`;
+			return;
+		}
+
+		setLeverageValue(leverageInput);
+	}
+
+	function handleKeydown(event) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			commitInput();
+			event.currentTarget.blur();
+		}
+	}
+
+	$: if (!isEditingInput && `${$leverage}` !== leverageInput) {
+		leverageInput = `${$leverage}`;
 	}
 
 	$: saveLeverage($leverage);
@@ -26,7 +67,49 @@
 	.value {
 		font-size: 48px;
 		text-align: center;
-		padding-bottom: 25px;
+		padding-bottom: 12px;
+	}
+
+	.input-wrapper {
+		padding-bottom: 20px;
+	}
+
+	.input-label {
+		font-size: 12px;
+		font-weight: 600;
+		letter-spacing: 0.04rem;
+		text-transform: uppercase;
+		color: var(--text300);
+		padding-bottom: 8px;
+	}
+
+	.input {
+		width: 100%;
+		height: 48px;
+		box-sizing: border-box;
+		border-radius: 6px;
+		border: 1px solid var(--layer200);
+		background-color: var(--layer50);
+		color: var(--text0);
+		text-align: center;
+		font-size: 24px;
+		font-weight: 600;
+		caret-color: var(--primary);
+	}
+
+	.input:hover {
+		border-color: var(--layer300);
+	}
+
+	.input:focus {
+		border-color: var(--primary);
+	}
+
+	.helper {
+		padding-top: 8px;
+		font-size: 12px;
+		text-align: center;
+		color: var(--text300);
 	}
 	
 </style>
@@ -41,21 +124,24 @@
 
 		<div class='value'>{$leverage}×</div>
 
+		<div class='input-wrapper'>
+			<div class='input-label'>Type leverage</div>
+			<input
+				class='input'
+				type='number'
+				min='1'
+				max={$selectedMarketInfo.maxLeverage}
+				step='1'
+				bind:value={leverageInput}
+				on:input={handleInput}
+				on:blur={commitInput}
+				on:keydown={handleKeydown}
+			/>
+			<div class='helper'>Min 1× · Max {$selectedMarketInfo.maxLeverage}×</div>
+		</div>
+
 		<Slider bind:value={$leverage} maxValue={$selectedMarketInfo.maxLeverage} noTooltip={true} integersOnly={true} showDots={false}/>
 	
 	</div>
-
-	<!-- <div class='flex-row semi-padding-bottom'>
-		<div class='leverage-select'>
-			<input class='range' id='range' type='range' bind:this={rangeElem} bind:value={$leverage} min='1' max={$selectedMarketInfo.maxLeverage} on:mousedown={rangeIsActive} on:mouseup={rangeIsInactive}> 
-		</div>
-		<div class='value' class:active={rangeActive}>
-			<div bind:this={rangeValues}>
-				{#each leverages as lev}
-				<div>{lev}</div>
-				{/each}
-			</div>
-		</div>
-	</div> -->
 
 </Modal>


### PR DESCRIPTION
## Summary
- add a numeric leverage input alongside the existing slider
- clamp typed values to the market min/max leverage range
- keep slider and typed input in sync without overwriting active edits

## Testing
- npm run build

Closes #44