### PR TITLE
Add liquidation price chart toggle

### DIFF
--- a/src/components/modals/Settings.svelte
+++ b/src/components/modals/Settings.svelte
@@ -4,7 +4,7 @@
 	import LabelValue from '@components/layout/LabelValue.svelte'
 	import Checkbox from '@components/layout/Checkbox.svelte'
 
-	import { showOrdersOnChart, showPositionsOnChart, showTooltips } from '@lib/stores'
+	import { showOrdersOnChart, showPositionsOnChart, showLiquidationPriceOnChart, showTooltips } from '@lib/stores'
 	import { showToast } from '@lib/ui'
 	import { saveUserSetting } from '@lib/utils'
 
@@ -13,14 +13,15 @@
 		showToast('Settings reset.');
 	}
 
-	function saveSettings(soc, spc, st) {
+	function saveSettings(soc, spc, slpc, st) {
 		// console.log('saveSettings', soc, spc, st);
 		saveUserSetting('showOrdersOnChart', soc);
 		saveUserSetting('showPositionsOnChart', spc);
+		saveUserSetting('showLiquidationPriceOnChart', slpc);
 		saveUserSetting('showTooltips', st);
 	}
 
-	$: saveSettings($showOrdersOnChart, $showPositionsOnChart, $showTooltips);
+	$: saveSettings($showOrdersOnChart, $showPositionsOnChart, $showLiquidationPriceOnChart, $showTooltips);
 
 </script>
 
@@ -37,6 +38,9 @@
 	</div>
 	<div class='row'>
 		<Checkbox hasPadding={true} label='Positions on chart' bind:value={$showPositionsOnChart} />
+	</div>
+	<div class='row'>
+		<Checkbox hasPadding={true} label='Liquidation price on chart' bind:value={$showLiquidationPriceOnChart} />
 	</div><!-- 
 	<div class='row'>
 		<Checkbox hasPadding={true} label='Tooltips' bind:value={$showTooltips} />

--- a/src/lib/chart.js
+++ b/src/lib/chart.js
@@ -1,9 +1,9 @@
 import { get } from 'svelte/store'
 import { createChart, ColorType, LineStyle } from 'lightweight-charts'
 
-import { CURRENCY_DECIMALS } from './config'
+import { CURRENCY_DECIMALS, BPS_DIVIDER } from './config'
 import { formatUnits, formatOrder, formatPosition, formatForDisplay, formatPriceForDisplay } from './formatters'
-import { selectedMarket, orders, positions, chartResolution, chartLoading, showOrdersOnChart, showPositionsOnChart, hoveredOHLC } from './stores'
+import { selectedMarket, orders, positions, chartResolution, chartLoading, showOrdersOnChart, showPositionsOnChart, showLiquidationPriceOnChart, hoveredOHLC, fundingTrackers, marketInfos } from './stores'
 import { saveUserSetting, getPrecision } from './utils'
 
 import { getMarketCandles } from '@api/prices'
@@ -140,6 +140,15 @@ export function initChart(cb) {
 		loadPositionLines(_positions);
 	});
 	showPositionsOnChart.subscribe(() => {
+		loadPositionLines();
+	});
+	showLiquidationPriceOnChart.subscribe(() => {
+		loadPositionLines();
+	});
+	fundingTrackers.subscribe(() => {
+		loadPositionLines();
+	});
+	marketInfos.subscribe(() => {
 		loadPositionLines();
 	});
 
@@ -324,6 +333,7 @@ export function onNewPrice(price) {
 
 let orderLines = [];
 let positionLines = [];
+let liquidationLines = [];
 
 function loadOrderLines(_orders) {
 
@@ -373,9 +383,9 @@ function loadPositionLines(_positions) {
 	}
 
 	clearPositionLines();
+	clearLiquidationLines();
 
-
-	if (!get(showPositionsOnChart)) return;
+	if (!get(showPositionsOnChart) && !get(showLiquidationPriceOnChart)) return;
 
 	let markers = [];
 
@@ -385,16 +395,48 @@ function loadPositionLines(_positions) {
 
 		if (_position.market != get(selectedMarket)) continue;
 
-		positionLines.push(
-			candlestickSeries.createPriceLine({
-			    price: _position.price,
-			    color: _position.isLong ? '#00D604' : '#FF5000',
-			    lineWidth: 1,
-			    lineStyle: LineStyle.Solid,
-			    axisLabelVisible: true,
-			    title: `${_position.isLong ? '▲' : '▼'} ${formatForDisplay(_position.size)} ${_position.asset}`,
-			})
-		);
+		if (get(showPositionsOnChart)) {
+			positionLines.push(
+				candlestickSeries.createPriceLine({
+				    price: _position.price,
+				    color: _position.isLong ? '#00D604' : '#FF5000',
+				    lineWidth: 1,
+				    lineStyle: LineStyle.Solid,
+				    axisLabelVisible: true,
+				    title: `${_position.isLong ? '▲' : '▼'} ${formatForDisplay(_position.size)} ${_position.asset}`,
+				})
+			);
+		}
+
+		if (get(showLiquidationPriceOnChart)) {
+			const liqThreshold = get(marketInfos)?.[_position.market]?.liqThreshold;
+			const fundingTracker = get(fundingTrackers)?.[_position.asset]?.[_position.market];
+			if (liqThreshold && fundingTracker != undefined) {
+				let ftDiff = fundingTracker * 1 - (_position.fundingTracker * 1);
+				if (_position.isLong) ftDiff = -1 * ftDiff;
+				const funding = _position.size * ftDiff / BPS_DIVIDER || 0;
+				const marginWithFunding = _position.margin * 1 + funding * 1;
+				const liqFactor = liqThreshold / BPS_DIVIDER;
+				let liqPrice;
+				if (_position.isLong) {
+					liqPrice = _position.price * 1 - liqFactor * marginWithFunding * _position.price / _position.size;
+				} else {
+					liqPrice = _position.price * 1 + liqFactor * marginWithFunding * _position.price / _position.size;
+				}
+				if (!isNaN(liqPrice) && isFinite(liqPrice)) {
+					liquidationLines.push(
+						candlestickSeries.createPriceLine({
+							price: liqPrice,
+							color: '#FF5A5F',
+							lineWidth: 1,
+							lineStyle: LineStyle.Dashed,
+							axisLabelVisible: true,
+							title: `Liq ${_position.isLong ? '▲' : '▼'} ${formatForDisplay(_position.size)} ${_position.asset}`,
+						})
+					);
+				}
+			}
+		}
 
 		// markers.push({
 		// 	time: _position.timestamp.toNumber(),
@@ -433,4 +475,11 @@ function clearPositionLines() {
 	}
 	candlestickSeries.setMarkers([]);
 	positionLines = [];
+}
+
+function clearLiquidationLines() {
+	for (const priceline of liquidationLines) {
+		candlestickSeries.removePriceLine(priceline);
+	}
+	liquidationLines = [];
 }

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -23,6 +23,7 @@ export const activeError = writable();
 export const showMobileNav = writable(false);
 export const showOrdersOnChart = writable(getUserSetting('showOrdersOnChart') == undefined ? true : getUserSetting('showOrdersOnChart'));
 export const showPositionsOnChart = writable(getUserSetting('showPositionsOnChart') == undefined ? true : getUserSetting('showPositionsOnChart'));
+export const showLiquidationPriceOnChart = writable(getUserSetting('showLiquidationPriceOnChart') == undefined ? false : getUserSetting('showLiquidationPriceOnChart'));
 export const showTooltips = writable(getUserSetting('showTooltips') == undefined ? true : getUserSetting('showTooltips'));
 
 // Contracts


### PR DESCRIPTION
## Summary
- add a new `showLiquidationPriceOnChart` setting persisted alongside the existing chart toggles
- render a dashed liquidation price line for each open position on the active market
- recalculate liquidation lines when funding trackers / market info change so the chart stays in sync

## Testing
- `npm run build`

Closes #7
