### PR TITLE
Fix max close size formatting

### DIFF
--- a/src/components/modals/ClosePosition.svelte
+++ b/src/components/modals/ClosePosition.svelte
@@ -20,6 +20,7 @@
 	export let data;
 
 	let amount, isSubmitting, sizeToClosePercent = 0;
+	$: maxSizeToClose = formatForDisplay(data.size);
 
 	async function submit() {
 		if (!amount) return focusInput('Size to Close');
@@ -96,7 +97,7 @@
 			</div>
 
 			<div class='row'>
-				<LabelValue label='Max' value={`${formatForDisplay(data.size)} ${data.asset}`} on:click={() => amount = data.size} isClickable={true} />
+				<LabelValue label='Max' value={`${maxSizeToClose} ${data.asset}`} on:click={() => amount = `${maxSizeToClose}`} isClickable={true} />
 			</div>
 
 			<div class='row'>


### PR DESCRIPTION
Fixes #11.

## Summary
- reuse the formatted Max size value in the close-position modal
- set the input to the formatted value when Max is clicked, avoiding raw floating-point artifacts

## Validation
- Not run; scoped Svelte UI change only.

Payout address: 0xe87b4889baeee4ed60a1b2bfc7b3a6a17bce4ad6