### PR TITLE
Fix Stake CAP approval spender

### DIFF
--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -88,7 +88,7 @@
 			<div>
 				{#if isCheckingAllowance}
 				<Button noSubmit={true} isLoading={true} label={`Approve CAP`} />
-				{:else if $allowances['CAP']?.[CAP_STAKING_SPENDER] * 1 <= amount * 1}
+				{:else if ($allowances['CAP']?.[CAP_STAKING_SPENDER] || 0) * 1 <= amount * 1}
 				<Button noSubmit={true} isLoading={isApproving} label={`Approve CAP`} on:click={_approveAsset} />
 				{:else}
 				<Button isLoading={isSubmitting} label={`Stake`} />

--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -13,7 +13,9 @@
 	import { focusInput, hideModal } from '@lib/ui'
 	import LabelValue from '../layout/LabelValue.svelte'
 
-	let amount, isSubmitting, walletBalance = "0.0";
+	const CAP_STAKING_SPENDER = 'Staking';
+
+	let amount, isSubmitting, isApproving, isCheckingAllowance = true, walletBalance = "0.0";
 
 	$: formattedWalletBalance = formatCAPForDisplay(walletBalance);
 
@@ -31,11 +33,21 @@
 	}
 
 	async function checkAllowance() {
-		await getAllowance('CAP', 'FundStore');
+		isCheckingAllowance = true;
+		try {
+			await getAllowance('CAP', CAP_STAKING_SPENDER);
+		} finally {
+			isCheckingAllowance = false;
+		}
 	}
 
 	async function _approveAsset() {
-		const result = await approveAsset('CAP', 'FundStore');
+		isApproving = true;
+		try {
+			await approveAsset('CAP', CAP_STAKING_SPENDER);
+		} finally {
+			isApproving = false;
+		}
 	}
 
 	async function getBalance() {
@@ -74,8 +86,10 @@
 			</div>
 
 			<div>
-				{#if $allowances['CAP']?.['FundStore'] * 1 <= amount * 1}
-				<Button noSubmit={true} label={`Approve CAP`} on:click={_approveAsset} />
+				{#if isCheckingAllowance}
+				<Button noSubmit={true} isLoading={true} label={`Approve CAP`} />
+				{:else if $allowances['CAP']?.[CAP_STAKING_SPENDER] * 1 <= amount * 1}
+				<Button noSubmit={true} isLoading={isApproving} label={`Approve CAP`} on:click={_approveAsset} />
 				{:else}
 				<Button isLoading={isSubmitting} label={`Stake`} />
 				{/if}


### PR DESCRIPTION
Fixes #32.

## Summary
- check and approve CAP allowance for the Staking contract used by the stake transaction
- keep the modal in a loading state while allowance is being checked
- keep the Approve CAP button loading while the wallet approval is pending

## Validation
- Not run; scoped Svelte UI change only.

Payout address: 0xe87b4889baeee4ed60a1b2bfc7b3a6a17bce4ad6