### PR TITLE
Use exact CAP balances for max stake actions

### DIFF
--- a/src/components/modals/StakeCAP.svelte
+++ b/src/components/modals/StakeCAP.svelte
@@ -42,6 +42,10 @@
 		walletBalance = await getCAPWalletBalance();
 	}
 
+	function setMaxAmount() {
+		amount = walletBalance || 0;
+	}
+
 	checkAllowance();
 	getBalance();
 
@@ -69,7 +73,7 @@
 					value={formattedWalletBalance}
 					isClickable={true}
 					hasSemiPadding={true}
-					on:click={() => { amount = formattedWalletBalance; }}
+					on:click={setMaxAmount}
 				/>
 			</div>
 

--- a/src/components/modals/UnstakeCAP.svelte
+++ b/src/components/modals/UnstakeCAP.svelte
@@ -33,6 +33,10 @@
 		focusInput('Amount');
 	});
 
+	function setMaxAmount() {
+		amount = $CAPStake || 0;
+	}
+
 
 </script>
 
@@ -53,7 +57,7 @@
 					value={formattedCAPStaked}
 					isClickable={true}
 					hasSemiPadding={true}
-					on:click={() => { amount = formattedCAPStaked; }}
+					on:click={setMaxAmount}
 				/>
 			</div>
 


### PR DESCRIPTION
Fixes #60.

## Summary
- keep the displayed CAP balance rounded for readability
- use the exact wallet balance when the Stake CAP max row is clicked
- use the exact staked CAP amount when the Unstake CAP max row is clicked

This prevents the max shortcut from writing a rounded display value that can exceed the actual spendable/staked amount.

## Validation
- `git diff --check`
- Not run: full build dependencies are not installed in this clean checkout.

Payout address: 0xe87b4889baeee4ed60a1b2bfc7b3a6a17bce4ad6